### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -36,7 +36,7 @@ Resources:
     Properties:
       CodeUri: subscriber/
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Role: !GetAtt SubscriberRole.Arn
       Description: 'Polls Amazon MQ broker for messages and pushes to worker function'
       Timeout: 15
@@ -58,7 +58,7 @@ Resources:
     Properties:
       CodeUri: worker/
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Role: !GetAtt WorkerRole.Arn
       Description: 'Writes incoming message to DynamoDB'
       Environment:


### PR DESCRIPTION
CloudFormation templates in amazonmq-invoke-aws-lambda have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.